### PR TITLE
Fix mcumgr 'fs upload' handling

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -306,7 +306,7 @@ cbor_internal_read_object(CborValue *root_value,
                 err |= CborErrorIllegalType;
             }
         }
-        cbor_value_advance(&cur_value);
+        err = cbor_value_advance(&cur_value);
     }
     if (!err) {
         /* that should be it for this container */


### PR DESCRIPTION
err value was not properly updated when doing 'fs upload', causing errors on file uploads larger than single packet.
Desktop verified that slot image uploads (vs file uploads) are unaffected.