### PR TITLE
Speed up file system uploads

### DIFF
--- a/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
@@ -115,10 +115,10 @@ fs_mgmt_impl_write(const char *path, size_t offset, const void *data,
     static char *previous_path = NULL;
     int rc;
 
-    /* If there isn't a previously-opened file path or this write
-     * is for a different file path than that previous one...
+    /* If this is the write of the first chunk or there isn't a previously-opened
+     * file path or this write is for a different file path than that previous one...
      */
-    if (previous_path == NULL || strcmp(path, previous_path) != 0) {
+    if (offset == 0 || previous_path == NULL || strcmp(path, previous_path) != 0) {
         /* If there is a previously-opened file path, close the
          * file and free the storage allocated for the file path
          */


### PR DESCRIPTION
This PR improves the speed of file systems uploads with `mcumgr fs upload` considerably by keeping the file descriptor in an open state throughout the upload, instead of closing it after every chunk. This avoids the overhead of opening the file and then seeking to the end of the file before writing on every 1 KB chunk, which has an O(n) penalty as file size grows on file systems like FAT due to their simplistic singly-linked block chaining scheme. The improvement in the upload speed of a 64 MB file into the RAM disk is considerable. Before:
```
lab@nuc-5:~$ dd if=/dev/urandom of=random.dat bs=1M count=64
64+0 records in
64+0 records out
67108864 bytes (67 MB, 64 MiB) copied, 0.691947 s, 97.0 MB/s
lab@nuc-5:~$ time ./go/bin/mcumgr -r 3 --conntype udp --connstring 192.168.1.134:1337 fs upload random.dat /RAM:/random.dat
Done8864

real	15m29.880s
...
```
After:
```
lab@nuc-5:~$ dd if=/dev/urandom of=random.dat bs=1M count=64
64+0 records in
64+0 records out
67108864 bytes (67 MB, 64 MiB) copied, 0.652001 s, 103 MB/s
lab@nuc-5:~$ time ./go/bin/mcumgr -r 3 --conntype udp --connstring 192.168.1.134:1337 fs upload random.dat /RAM:/random.dat
Done8864

real	4m5.031s
...
```

P.S.: Reviewing the `diff`s with [whitespace and indentation ignored](https://github.com/recogni/mcumgr/pull/6/files?w=1) results a better visualization of the changes.